### PR TITLE
Fixed problem with after_commit callback after destroy action

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -70,6 +70,7 @@ module Paranoia
           association.decrement_counters
         end
         @_disable_counter_cache = false
+        @_trigger_destroy_callback = true
         result
       end
     end


### PR DESCRIPTION
The current version of gem is not triggering the after_commit callback in case that destroy is called on model using act_as_paranoid.

This PR is fixing this issue and adding a test for it.